### PR TITLE
Added some implementation to better suits different projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ return [
      * Default is 'lang' it can be set to 'resources/lang'
      */
     'lang_path' => env('TOLGEE_LANG_PATH', 'lang'),
-    
+
     /*
-     * Specify a language files subfolder, in order to filter specific language files
+     * Specify a language files subfolder, in order to filter specific language files.Please be aware that this applies to subfolders within your base local folders.
+     * So if you have folder structure like `lang/en/messages/...`, you can set this env variable to `messages` and package will use only files from messages folder.
      */
-    'lang_subfolder' => env('TOLGEE_LANG_SUBFOLDER', null),
+    'lang_subfolder' => env('TOLGEE_LANG_SUBFOLDER'),
 
     /*
      * Host to you Tolgee service instance
@@ -51,19 +52,21 @@ return [
      * Api key needs to have all permissions to manage project.
      */
     'api_key' => env('TOLGEE_API_KEY'),
-    
+
     /**
      * Base locale of the project.
+     * Please note that the locale you set here should match the base language in your project.
      */
     'locale' => env('TOLGEE_LOCALE', 'en'),
-    
+
     /**
      * Override base locale translations files.
      */
     'override' => env('TOLGEE_OVERRIDE', false),
-    
+
     /**
-     * Accepted states for translations.
+     * Accepted translation states. Check Tolgee documentation for available states.
+     * Ex: REVIEWED,DISABLED,UNTRANSLATED,TRANSLATED
      */
     'accepted_states' => explode(",", env('TOLGEE_ACCEPTED_STATES', 'REVIEWED')),
 ];
@@ -158,7 +161,6 @@ When you setup is dockerized, you will need to set TOLGEE_HOST for docker intern
 
 ## Limitations
 
-You are need to use English as base language.</br>
 All operations are constrained to one project.
 
 This will be fixed/implemented in the future.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ return [
      * Override base locale translations files.
      */
     'override' => env('TOLGEE_OVERRIDE', false),
+    
+    /**
+     * Accepted states for translations.
+     */
+    'accepted_states' => explode(",", env('TOLGEE_ACCEPTED_STATES', 'REVIEWED')),
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ return [
      * Api key needs to have all permissions to manage project.
      */
     'api_key' => env('TOLGEE_API_KEY'),
+    
+    /**
+     * Base locale of the project.
+     */
+    'locale' => env('TOLGEE_LOCALE', 'en'),
+    
+    /**
+     * Override base locale translations files.
+     */
+    'override' => env('TOLGEE_OVERRIDE', false),
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ return [
      * Default is 'lang' it can be set to 'resources/lang'
      */
     'lang_path' => env('TOLGEE_LANG_PATH', 'lang'),
+    
+    /*
+     * Specify a language files subfolder, in order to filter specific language files
+     */
+    'lang_subfolder' => env('TOLGEE_LANG_SUBFOLDER', null),
 
     /*
      * Host to you Tolgee service instance

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -1,17 +1,17 @@
 <?php
 
-// config for Dusan Antonijevic/LaravelTolgee
 return [
     /*
      * Specify the path to your language files
      * Default is 'lang' it can be set to 'resources/lang'
      */
     'lang_path' => env('TOLGEE_LANG_PATH', 'lang'),
-    
+
     /*
-     * Specify a language files subfolder, in order to filter specific language files
+     * Specify a language files subfolder, in order to filter specific language files.Please be aware that this applies to subfolders within your base local folders.
+     * So if you have folder structure like `lang/en/messages/...`, you can set this env variable to `messages` and package will use only files from messages folder.
      */
-    'lang_subfolder' => env('TOLGEE_LANG_SUBFOLDER', null),
+    'lang_subfolder' => env('TOLGEE_LANG_SUBFOLDER'),
 
     /*
      * Host to you Tolgee service instance
@@ -30,19 +30,21 @@ return [
      * Api key needs to have all permissions to manage project.
      */
     'api_key' => env('TOLGEE_API_KEY'),
-    
+
     /**
      * Base locale of the project.
+     * Please note that the locale you set here should match the base language in your project.
      */
     'locale' => env('TOLGEE_LOCALE', 'en'),
-    
+
     /**
      * Override base locale translations files.
      */
     'override' => env('TOLGEE_OVERRIDE', false),
-    
+
     /**
-     * Accepted states for translations.
+     * Accepted translation states. Check Tolgee documentation for available states.
+     * Ex: REVIEWED,DISABLED,UNTRANSLATED,TRANSLATED
      */
     'accepted_states' => explode(",", env('TOLGEE_ACCEPTED_STATES', 'REVIEWED')),
 ];

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -30,5 +30,9 @@ return [
      * Locale of the project.
      */
     'locale' => env('TOLGEE_LOCALE', 'en'),
-
+    
+    /**
+     * Override base language translations files.
+     */
+    'override' => env('TOLGEE_OVERRIDE', false),
 ];

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -27,12 +27,12 @@ return [
     'api_key' => env('TOLGEE_API_KEY'),
     
     /**
-     * Locale of the project.
+     * Base locale of the project.
      */
     'locale' => env('TOLGEE_LOCALE', 'en'),
     
     /**
-     * Override base language translations files.
+     * Override base locale translations files.
      */
     'override' => env('TOLGEE_OVERRIDE', false),
 ];

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -25,5 +25,10 @@ return [
      * Api key needs to have all permissions to manage project.
      */
     'api_key' => env('TOLGEE_API_KEY'),
+    
+    /**
+     * Locale of the project.
+     */
+    'locale' => env('TOLGEE_LOCALE', 'en'),
 
 ];

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -7,6 +7,11 @@ return [
      * Default is 'lang' it can be set to 'resources/lang'
      */
     'lang_path' => env('TOLGEE_LANG_PATH', 'lang'),
+    
+    /*
+     * Specify a language files subfolder, in order to filter specific language files
+     */
+    'lang_subfolder' => env('TOLGEE_LANG_SUBFOLDER', null),
 
     /*
      * Host to you Tolgee service instance

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -35,4 +35,9 @@ return [
      * Override base locale translations files.
      */
     'override' => env('TOLGEE_OVERRIDE', false),
+    
+    /**
+     * Accepted states for translations.
+     */
+    'accepted_states' => explode(",", env('TOLGEE_ACCEPTED_STATES', 'REVIEWED')),
 ];

--- a/src/Integration/Tolgee.php
+++ b/src/Integration/Tolgee.php
@@ -72,4 +72,18 @@ class Tolgee
 
         return $parse ? $request->json() : $request;
     }
+
+    public function getAllTranslations()
+    {
+        $translations = [];
+        $page = 0;
+        
+        do {
+            $response = $this->getTranslationsRequest($page, true);
+            $translations = array_merge($translations, $response['_embedded']['keys']);
+            $page++;
+        } while ($page < $response['page']['totalPages']);
+        
+        return $translations;
+    }
 }

--- a/src/Integration/Tolgee.php
+++ b/src/Integration/Tolgee.php
@@ -49,6 +49,20 @@ class Tolgee
             ->delete('/v2/projects/{project}/keys', ['ids' => $data]);
     }
 
+    public function getAllTranslations(): array
+    {
+        $translations = [];
+        $page = 0;
+
+        do {
+            $response = $this->getTranslationsRequest($page, true);
+            $translations = array_merge($translations, $response['_embedded']['keys']);
+            $page++;
+        } while ($page < $response['page']['totalPages']);
+
+        return $translations;
+    }
+
     public function getTranslationsRequest(int $page = 0, bool $parse = false): PromiseInterface|Response|array
     {
         $languages = Http::withHeaders($this->headers)
@@ -71,19 +85,5 @@ class Tolgee
             ->get('/v2/projects/{project}/translations?' . $queryLanguages . 'page=' . $page);
 
         return $parse ? $request->json() : $request;
-    }
-
-    public function getAllTranslations()
-    {
-        $translations = [];
-        $page = 0;
-        
-        do {
-            $response = $this->getTranslationsRequest($page, true);
-            $translations = array_merge($translations, $response['_embedded']['keys']);
-            $page++;
-        } while ($page < $response['page']['totalPages']);
-        
-        return $translations;
     }
 }

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -37,7 +37,10 @@ class TolgeeService
             $filePath = $translationItem['keyNamespace'];
 
             foreach ($translationItem['translations'] as $locale => $translation) {
-                if ($locale === $this->config["locale"] && !$this->config["override"]) continue;
+                if (
+                    ($locale === $this->config["locale"] && !$this->config["override"]) ||
+                    ($locale !== $this->config["locale"] && !in_array($translation['state'], $this->config["accepted_states"]))
+                ) continue;
 
                 $localPathName = Str::replace('/'.$this->config["locale"], '/' . $locale, $filePath);
                 $writeArray = [$keyName => $translation['text']];

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -41,11 +41,11 @@ class TolgeeService
                 $filePath = $translationItem['keyNamespace'];
 
                 foreach ($translationItem['translations'] as $locale => $translation) {
-                    if ($locale === 'en') {
+                    if ($locale === $this->config["locale"]) {
                         continue;
                     }
 
-                    $localPathName = Str::replace('/en', '/' . $locale, $filePath);
+                    $localPathName = Str::replace('/'.$this->config["locale"], '/' . $locale, $filePath);
                     $writeArray = [$keyName => $translation['text']];
 
                     $prepare[$localPathName][] = $writeArray;
@@ -106,7 +106,7 @@ class TolgeeService
         foreach ($this->files->directories($this->config['lang_path']) as $langPath) {
             $locale = basename($langPath);
 
-            if ($locale !== 'en') {
+            if ($locale !== $this->config["locale"]) {
                 continue;
             }
 
@@ -120,7 +120,7 @@ class TolgeeService
         // Prepare vendor translations
         if ($this->files->exists($this->config['lang_path'] . '/vendor') && $withVendor) {
             foreach ($this->files->directories($this->config['lang_path'] . '/vendor') as $langPath) {
-                foreach ($this->files->allFiles($langPath . '/en') as $file) {
+                foreach ($this->files->allFiles($langPath . '/'.$this->config["locale"]) as $file) {
                     $translations = include $file;
 
                     $prepare[$file->getPathname()] = Arr::dot($translations);
@@ -136,7 +136,7 @@ class TolgeeService
 
             $locale = basename($jsonFile, '.json');
 
-            if ($locale !== 'en') {
+            if ($locale !== $this->config["locale"]) {
                 continue;
             }
 
@@ -150,7 +150,7 @@ class TolgeeService
                 if (is_array($value)) {
                     continue;
                 }
-                $import[] = ['name' => $key, 'namespace' => $namespace, 'translations' => ['en' => $value]];
+                $import[] = ['name' => $key, 'namespace' => $namespace, 'translations' => [$this->config["locale"] => $value]];
             }
         }
 

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -103,30 +103,36 @@ class TolgeeService
             $locale = basename($langPath);
 
             if ($locale !== $this->config["locale"]) continue;
+            
+            if(!is_null($this->config["lang_subfolder"])) {
+                $langPath .= '/'.$this->config["lang_subfolder"];
+            }
 
             foreach ($this->files->allfiles($langPath) as $file) {
                 $prepare[$file->getPathname()] = Arr::dot(include $file);
             }
         }
 
-        // Prepare vendor translations
-        if ($this->files->exists($this->config['lang_path'] . '/vendor') && $withVendor) {
-            foreach ($this->files->directories($this->config['lang_path'] . '/vendor') as $langPath) {
-                foreach ($this->files->allFiles($langPath . '/'.$this->config["locale"]) as $file) {
-                    $prepare[$file->getPathname()] = Arr::dot(include $file);
+        if(is_null($this->config["lang_subfolder"])) {
+            // Prepare vendor translations
+            if ($this->files->exists($this->config['lang_path'] . '/vendor') && $withVendor) {
+                foreach ($this->files->directories($this->config['lang_path'] . '/vendor') as $langPath) {
+                    foreach ($this->files->allFiles($langPath . '/'.$this->config["locale"]) as $file) {
+                        $prepare[$file->getPathname()] = Arr::dot(include $file);
+                    }
                 }
             }
-        }
 
-        // Prepare json files translations
-        foreach ($this->files->files($this->config['lang_path']) as $jsonFile) {
-            if (!str_contains($jsonFile, '.json')) continue;
+            // Prepare json files translations
+            foreach ($this->files->files($this->config['lang_path']) as $jsonFile) {
+                if (!str_contains($jsonFile, '.json')) continue;
 
-            $locale = basename($jsonFile, '.json');
+                $locale = basename($jsonFile, '.json');
 
-            if ($locale !== $this->config["locale"]) continue;
-            
-            $prepare[$jsonFile->getPathname()] = Arr::dot(Lang::getLoader()->load($locale, '*', '*'));
+                if ($locale !== $this->config["locale"]) continue;
+                
+                $prepare[$jsonFile->getPathname()] = Arr::dot(Lang::getLoader()->load($locale, '*', '*'));
+            }
         }
 
         // Remap everything into Tolgee request format

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -106,14 +106,10 @@ class TolgeeService
         foreach ($this->files->directories($this->config['lang_path']) as $langPath) {
             $locale = basename($langPath);
 
-            if ($locale !== $this->config["locale"]) {
-                continue;
-            }
+            if ($locale !== $this->config["locale"]) continue;
 
             foreach ($this->files->allfiles($langPath) as $file) {
-                $translations = include $file;
-
-                $prepare[$file->getPathname()] = Arr::dot($translations);
+                $prepare[$file->getPathname()] = Arr::dot(include $file);
             }
         }
 
@@ -121,35 +117,27 @@ class TolgeeService
         if ($this->files->exists($this->config['lang_path'] . '/vendor') && $withVendor) {
             foreach ($this->files->directories($this->config['lang_path'] . '/vendor') as $langPath) {
                 foreach ($this->files->allFiles($langPath . '/'.$this->config["locale"]) as $file) {
-                    $translations = include $file;
-
-                    $prepare[$file->getPathname()] = Arr::dot($translations);
+                    $prepare[$file->getPathname()] = Arr::dot(include $file);
                 }
             }
         }
 
         // Prepare json files translations
         foreach ($this->files->files($this->config['lang_path']) as $jsonFile) {
-            if (!str_contains($jsonFile, '.json')) {
-                continue;
-            }
+            if (!str_contains($jsonFile, '.json')) continue;
 
             $locale = basename($jsonFile, '.json');
 
-            if ($locale !== $this->config["locale"]) {
-                continue;
-            }
-
-            $translations = Lang::getLoader()->load($locale, '*', '*');
-            $prepare[$jsonFile->getPathname()] = Arr::dot($translations);
+            if ($locale !== $this->config["locale"]) continue;
+            
+            $prepare[$jsonFile->getPathname()] = Arr::dot(Lang::getLoader()->load($locale, '*', '*'));
         }
 
         // Remap everything into Tolgee request format
         foreach ($prepare as $namespace => $keys) {
             foreach ($keys as $key => $value) {
-                if (is_array($value)) {
-                    continue;
-                }
+                if (is_array($value)) continue;
+                
                 $import[] = ['name' => $key, 'namespace' => $namespace, 'translations' => [$this->config["locale"] => $value]];
             }
         }

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -41,7 +41,7 @@ class TolgeeService
                 $filePath = $translationItem['keyNamespace'];
 
                 foreach ($translationItem['translations'] as $locale => $translation) {
-                    if ($locale === $this->config["locale"]) {
+                    if ($locale === $this->config["locale"] && !$this->config["override"]) {
                         continue;
                     }
 


### PR DESCRIPTION
1. Added an option to change the default locale for the project, it can be set with the parameter **TOLGEE_LOCALE** in the .env file
2. Added an option to override the default locale translation files, it can be set with the parameter **TOLGEE_OVERRIDE** in the .env file
3. Added an option to filter translations state in order to accept only the reviewed translation, it can be set with the parameter **TOLGEE_ACCEPTED_STATES** in the .env file as a comma separated list, eg. "TRANSLATED,REVIEWED", according to the [Tolgee API](https://tolgee.io/api/get-translations)
4. Added an option to specify a translation files subfolder in order to translate only a distinct group of files, it can be set with the parameter **TOLGEE_LANG_SUBFOLDER** in the .env file
5. Refactoring TolgeeService.php and Tolgee.php