### PR TITLE
New translation sync logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ return [
      * Ex: REVIEWED,DISABLED,UNTRANSLATED,TRANSLATED
      */
     'accepted_states' => explode(",", env('TOLGEE_ACCEPTED_STATES', 'REVIEWED')),
+
+    /**
+     * Makes translations files prettier
+     */
+    'pretty_file' => env('TOLGEE_PRETTY_FILE', true),
 ];
 ```
 

--- a/config/tolgee.php
+++ b/config/tolgee.php
@@ -47,4 +47,9 @@ return [
      * Ex: REVIEWED,DISABLED,UNTRANSLATED,TRANSLATED
      */
     'accepted_states' => explode(",", env('TOLGEE_ACCEPTED_STATES', 'REVIEWED')),
+
+    /**
+     * Makes translations files prettier
+     */
+    'pretty_file' => env('TOLGEE_PRETTY_FILE', true),
 ];

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -115,10 +115,8 @@ class TolgeeService
         if (!$this->config['lang_subfolder']) {
             // Prepare vendor translations
             if ($this->files->exists($this->config['lang_path'] . '/vendor') && $withVendor) {
-                foreach ($this->files->directories($this->config['lang_path'] . '/vendor') as $langPath) {
-                    foreach ($this->files->allFiles($langPath . '/'.$this->config['locale']) as $file) {
-                        $prepare[$file->getPathname()] = Arr::dot(include $file);
-                    }
+                foreach ($this->files->allFiles($this->config['lang_path'] . '/vendor/'.$this->config['locale']) as $file) {
+                    $prepare[$file->getPathname()] = Arr::dot(include $file);
                 }
             }
 

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -38,7 +38,7 @@ class TolgeeService
             foreach ($translationItem['translations'] as $locale => $translation) {
                 if (
                     ($locale === $this->config['locale'] && !$this->config['override']) ||
-                    ($locale !== $this->config['locale'] && !in_array($translation['state'], $this->config['accepted_states']))
+                    (!in_array($translation['state'], $this->config['accepted_states']))
                 ) {
                     continue;
                 }

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -61,7 +61,7 @@ class TolgeeService
                             return {{translations}};
                             
                             EOT;
-            $prettyWriteArray = VarExport::pretty($writeArray, ['array-align' => true]);
+            $prettyWriteArray = VarExport::pretty($writeArray, ['array-align' => $this->config['pretty_file']]);
             $fileContent = Str::replace('{{translations}}', $prettyWriteArray, $fileContent);
 
             $this->files->ensureDirectoryExists(dirname($localPathName));

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -158,21 +158,15 @@ class TolgeeService
     private function getFileTranslationsArray($filePath){
         $data = [];
         
+        if(!$this->files->exists($filePath)){
+            return $data;
+        }
+        
         if(Str::contains($filePath, '.json')){
-            $lang_path = $this->config['lang_path'];
-            
-            preg_match("/$lang_path\/([^.]+)/i", $filePath, $language);
-            
-            $data = Lang::getLoader()->load($language[1], '*', '*');
+            $data = json_decode($this->files->get($filePath), true);
         }
         else{
-            $translation_key = preg_replace("/{$this->config["lang_path"]}\/[^\/]+\/|.php/i", '', $filePath);
-            preg_match("/{$this->config["lang_path"]}\/([^\/]+)\//i", $filePath, $language);
-            $data = Lang::get($translation_key, locale: $language[1], fallback: false);
-            
-            if($data == $translation_key){
-                $data = [];
-            }
+            $data = include $filePath;
         }
         
         return $data;

--- a/src/Services/TolgeeService.php
+++ b/src/Services/TolgeeService.php
@@ -102,20 +102,14 @@ class TolgeeService
         $import = [];
 
         // Prepare local .php files
-        foreach ($this->files->directories($this->config['lang_path']) as $langPath) {
-            $locale = basename($langPath);
-
-            if ($locale !== $this->config['locale']) {
-                continue;
-            }
-
-            if ($this->config['lang_subfolder']) {
-                $langPath .= '/'.$this->config['lang_subfolder'];
-            }
-
-            foreach ($this->files->allfiles($langPath) as $file) {
-                $prepare[$file->getPathname()] = Arr::dot(include $file);
-            }
+        $langPath = $this->config['lang_path']."/".$this->config['locale'];
+        
+        if ($this->config['lang_subfolder']) {
+            $langPath .= '/'.$this->config['lang_subfolder'];
+        }
+        
+        foreach ($this->files->allfiles($langPath) as $file) {
+            $prepare[$file->getPathname()] = Arr::dot(include $file);
         }
 
         if (!$this->config['lang_subfolder']) {


### PR DESCRIPTION
- Updated the Sync Translations logic in order to use the translations files array as a base for the translation sync, this change prevent unsync local translation to be lost
- Added an option to disable the formatting of the .php translations files on sync
- Some code improvement